### PR TITLE
fix dependency issue when not explicitly building dlt-core jar

### DIFF
--- a/.github/workflows/build_with_tests.yml
+++ b/.github/workflows/build_with_tests.yml
@@ -11,8 +11,10 @@ permissions:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        runs-on: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK
@@ -24,12 +26,12 @@ jobs:
         uses: gradle/gradle-build-action@v3
       - name: build and test
         run: |
-          ./gradlew build 
-          ./gradlew jar 
-          ./gradlew packageUberJarForCurrentOS
+          ./gradlew clean build test packageUberJarForCurrentOS packageDistributionForCurrentOS
       - name: upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: uber-jar
+          name: job-data-${{ matrix.runs-on }}
           path: |
             dlt-filter-app/build/compose/jars/dlt-filter*
+            dlt-filter-app/build/compose/binaries/**/*.deb
+            dlt-filter-app/build/compose/binaries/**/*.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
         uses: gradle/gradle-build-action@v3
       - name: build and test
         run: |
-          ./gradlew build 
-          ./gradlew jar 
           ./gradlew packageDistributionForCurrentOS
       - name: upload artifacts
         uses: actions/upload-artifact@v4

--- a/dlt-filter-app/build.gradle.kts
+++ b/dlt-filter-app/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
+tasks.named("jar") {
+    dependsOn(":dlt-core:jar")
+}
+
 tasks.test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
fixes a build issue in which it would not build when dlt-core jar wasn't build beforehand by
declaring a dependency from dlt-filter:jar to dlt-core:jar